### PR TITLE
Add support for timeouts on the machine resource.

### DIFF
--- a/drp/resource_drp_machine.go
+++ b/drp/resource_drp_machine.go
@@ -53,6 +53,12 @@ func resourceMachine() *schema.Resource {
 	r.Update = resourceMachineUpdate
 	r.Delete = resourceMachineDelete
 
+	r.Timeouts = &schema.ResourceTimeout{
+		Create: schema.DefaultTimeout(25 * time.Minute),
+		Update: schema.DefaultTimeout(10 * time.Minute),
+		Delete: schema.DefaultTimeout(10 * time.Minute),
+	}
+
 	// Define what the machines completion stage.
 	r.Schema["completion_stage"] = &schema.Schema{
 		Type:     schema.TypeString,
@@ -325,7 +331,7 @@ func resourceMachineCreate(d *schema.ResourceData, meta interface{}) error {
 		Pending:    []string{"9:"},
 		Target:     []string{"6:"},
 		Refresh:    getMachineStatus(cc, machineObj.UUID(), stages),
-		Timeout:    25 * time.Minute,
+		Timeout:    d.Timeout(schema.TimeoutCreate),
 		Delay:      10 * time.Second,
 		MinTimeout: 3 * time.Second,
 	}


### PR DESCRIPTION
This adds create, update, and delete timeouts.
They are part of the base terraform operation.  Kinda cool.
Who knew?

Anyway, only create is used.  It is the only thing that iterates
through a timeout situation.  The other operations should all be
"quick" DRP API calls.

This addresses #43 