### PR TITLE
Add build tool calls in the makefile so that

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -6,6 +6,8 @@ WEBSITE_REPO=github.com/hashicorp/terraform-website
 default: build
 
 build: fmtcheck
+	go get github.com/kardianos/govendor
+	tools/build.sh
 	go install
 
 test: fmtcheck


### PR DESCRIPTION
go install will use the correct version of things.